### PR TITLE
CoC note from berlinjs.org

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -8,13 +8,24 @@ subtitle: Disclaimer
         <div class="textbody container">
             <div class="row">
 		        <div class="textbody-text span12">
-		            <h4>Code of Conduct</h4>
-		            <p>
-                        We're excellent to each other. :-) Any form of discrimination will not be tolerated.
-                    </p>
-                    <p>
-                        In case you have questions, concerns or anything else, please talk to <a href="imprint.html">the organizers</a>.
-		            </p>
+				<h4>Code of Conduct</h5>
+				<p>
+					We're excellent to each other. :-) Any form of discrimination will not be tolerated.
+				</p>
+				
+				<p>
+					Our goal is to have an awesome, inclusive and safe community meetup where people meet,
+					hang out together, chat, listen to talks, exchange ideas and make new friends.
+					Any harmful or discriminating behaviour will not be tolerated and results
+					in the offending person being expelled from the meetup.
+				</p>
+				
+				<p>
+					For details on what kinds of behaviour are not tolerated and consequences for violating these rules, we refer to the <a href="http://rubyberlin.github.io/code-of-conduct/">Berlin Code of Conduct</a>.
+				</p>
+				<p>
+					In case you have questions, concerns or anything else, please talk to <a href="imprint.html">the organizers</a>.
+				</p>
 	            </div>
             </div>
         </div>


### PR DESCRIPTION
As discussed with @rmehner on Twitter (https://twitter.com/rmehner/status/519777349370261504), this adds the same code-of-conduct note as I already added to http://berlinjs.org.

It links to the ["Berlin Code of Conduct"](http://rubyberlin.github.io/code-of-conduct/) that contains far more detailed guidelines that just "be excellent to each other".
