### PR TITLE
Added Talk about Behat tests for api-platform

### DIFF
--- a/_posts/2019-05-07-may.html
+++ b/_posts/2019-05-07-may.html
@@ -48,16 +48,24 @@ meetupdate: 2019-05-07
     {% comment %} ==== TALK / PRESENTATION - SLOT #3 ====     {% endcomment %}
 
     {% comment %} TITLE OF YOUR TALK:                         {% endcomment %}
-                  <h4>Free Slot</h4>
+                  <h4>Test drive your API with functional tests in Behat</h4>
 
     {% comment %} SUB-TITLE OR DESCRIPTION:                   {% endcomment %}
-                  <p>This 25 minute slot could be yours!</p>
-
-    {% comment %} REMOVE NEXT LINE:                           {% endcomment %}
-                  <p><a class="speaker" target="_blank" href="/submit.html"><strong>Submit your talk now</strong></a></p>
+                  <p>While there are many test tools that guarantee the health of code units, only 
+                     BDD oriented test scenarios ensure that also humans understand what's going on
+                     in your application. We're using Behat to write feature tests for our api-platform based API
+                     and it saved our life on Friday night deployments more than once. In this talk Stefan demonstrates how 
+                      <ul>
+                          <li>Behat is wired into a Symfony application</li>
+                          <li>to write database driven tests that don't interfere with each other</li>
+                          <li>to issue requests to the API and check their sideeffects</li>
+                          <li>mock a JWT authentication scheme</li>
+                          <li>write reusable context classes</li>
+                      </ul>
+    </p>
 
     {% comment %} UNCOMMENT/EDIT NEXT LINE:                   {% endcomment %}
-    <!-- <p><a class="speaker" target="_blank" href="https://twitter.com/...HOW-TO-CONTACT-YOU">YOUR NAME</a></p> -->
+    <p><a class="speaker" target="_blank" href="https://twitter.com/stadolf">Stefan Adolf | Developer Ambassador @ Turbine Kreuzberg</a></p>
 
 </div>
 


### PR DESCRIPTION
While there are many test tools that guarantee the health of code units, only BDD oriented test scenarios ensure that also humans understand what's going on in your application. We're using Behat to write feature tests for our api-platform based API                     and it saved our life on Friday night deployments more than once. In this talk Stefan demonstrates how 

- Behat is wired into a Symfony application
- to write database driven tests that don't interfere with each other
- to issue requests to the API and check their sideeffects
- mock a JWT authentication scheme
- write reusable context classes